### PR TITLE
feat(config): caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features
 - 
 
-## [1.2.0] - 2025-09-12
+## [1.3.0] - 2025-09-12
+
+### Added
+- **Caller Configuration**: Added `ShowCaller` field to `LoggerConfig` struct to control whether caller information is displayed in logs
+- **Default Caller Behavior**: Caller information is now shown by default (`ShowCaller: true`)
+- **Caller Control Examples**: Updated examples to demonstrate caller configuration usage
 
 ### Changed
-- Changed module name from github.com to personal go.risoftinc.com
+- **LoggerConfig Structure**: Added `ShowCaller bool` field to `LoggerConfig` struct
+- **Logger Struct**: Added `showCaller bool` field to `Logger` struct to store caller configuration
+- **initLogWithConfig Function**: Modified to conditionally add caller information based on `ShowCaller` configuration
+- **WithContext Method**: Updated to preserve caller configuration when creating new logger instances
+
+### Technical Details
+- Caller information is controlled by `zap.AddCaller()` and `zap.AddCallerSkip(1)` options
+- When `ShowCaller: false`, these options are not applied to the zap logger
+- Default behavior maintains backward compatibility by showing caller information
+- All existing functionality remains unchanged
+
+### Usage Example
+```go
+// Logger with caller information (default)
+log := gologger.NewLogger()
+
+// Logger without caller information
+config := gologger.LoggerConfig{
+    OutputMode: gologger.OutputTerminal,
+    LogLevel:   gologger.LevelInfo,
+    LogDir:     "logger",
+    ShowCaller: false, // Disable caller information
+}
+log := gologger.NewLoggerWithConfig(config)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A structured logging solution for Go applications using zap gologger. This packa
 - **Multiple Output Modes**: Terminal, file, or both
 - **Configurable Log Levels**: Debug, Info, Warn, Error
 - **Structured Logging**: JSON format with timestamps and caller information
+- **Caller Configuration**: Control whether to show caller information in logs (default: enabled)
 - **Log Rotation**: Automatic log file rotation using lumberjack
 - **Request Tracing**: Support for request ID tracking with custom key configuration (commonly used for HTTP request tracing)
 - **Method Chaining**: Fluent API for clean, readable code
@@ -81,12 +82,44 @@ func main() {
         OutputMode: gologger.OutputFile,
         LogLevel:   gologger.LevelInfo,
         LogDir:     "logs",
+        ShowCaller: true, // Show caller information (default: true)
     }
     
     log := gologger.NewLoggerWithConfig(config)
     defer log.Close()
 
     log.Info("Application started with custom config").Send()
+}
+```
+
+### Caller Configuration
+
+```go
+package main
+
+import (
+    "go.risoftinc.com/gologger"
+)
+
+func main() {
+    // Logger with caller information (default behavior)
+    logWithCaller := gologger.NewLogger()
+    defer logWithCaller.Close()
+    
+    logWithCaller.Info("This log will show caller information").Send()
+
+    // Logger without caller information
+    configWithoutCaller := gologger.LoggerConfig{
+        OutputMode: gologger.OutputTerminal,
+        LogLevel:   gologger.LevelInfo,
+        LogDir:     "logger",
+        ShowCaller: false, // Disable caller information
+    }
+    
+    logWithoutCaller := gologger.NewLoggerWithConfig(configWithoutCaller)
+    defer logWithoutCaller.Close()
+    
+    logWithoutCaller.Info("This log will NOT show caller information").Send()
 }
 ```
 
@@ -405,6 +438,7 @@ log.WithContext(ctx).
 - `LogLevel string`: Log level (`LevelDebug`, `LevelInfo`, `LevelWarn`, `LevelError`)
 - `LogDir string`: Directory for log files
 - `RequestIDKey string`: Custom key for request ID in logs (default: `"request-id"`)
+- `ShowCaller bool`: Whether to show caller information in logs (default: `true`)
 
 ### Context Functions
 
@@ -445,6 +479,7 @@ type gologger.LoggerConfig struct {
     LogLevel      string              // Log level: LevelDebug, LevelInfo, LevelWarn, or LevelError
     LogDir        string              // Directory for log files
     RequestIDKey  string              // Custom key for request ID in logs (default: "request-id")
+    ShowCaller    bool                // Whether to show caller information in logs (default: true)
     LogRotation   *LogRotationConfig  // Log rotation configuration (optional, uses defaults if nil)
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	// Example 1: Basic logging with method chaining
+	// Example 1: Basic logging with method chaining (with caller information by default)
 	log := gologger.NewLogger()
 	defer log.Close()
 
@@ -61,7 +61,20 @@ func main() {
 		Data("component", "system").
 		Send()
 
-	// Example 7: Simulating HTTP request flow
+	// Example 7: Logger configuration with caller control
+	// Create a logger without caller information
+	config := gologger.LoggerConfig{
+		OutputMode: gologger.OutputTerminal,
+		LogLevel:   gologger.LevelInfo,
+		LogDir:     "logger",
+		ShowCaller: false, // Disable caller information
+	}
+	logNoCaller := gologger.NewLoggerWithConfig(config)
+	defer logNoCaller.Close()
+
+	logNoCaller.Info("This log will not show caller information").Send()
+
+	// Example 8: Simulating HTTP request flow
 	simulateHTTPRequest(log)
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -369,6 +369,67 @@ func TestClose(t *testing.T) {
 	log.Close()
 }
 
+func TestShowCallerConfiguration(t *testing.T) {
+	// Test with ShowCaller = true (default)
+	configWithCaller := LoggerConfig{
+		OutputMode: OutputTerminal,
+		LogLevel:   LevelInfo,
+		LogDir:     "test_logs",
+		ShowCaller: true,
+	}
+
+	logWithCaller := NewLoggerWithConfig(configWithCaller)
+	defer logWithCaller.Close()
+
+	if !logWithCaller.showCaller {
+		t.Error("Expected showCaller to be true")
+	}
+
+	// Test with ShowCaller = false
+	configWithoutCaller := LoggerConfig{
+		OutputMode: OutputTerminal,
+		LogLevel:   LevelInfo,
+		LogDir:     "test_logs",
+		ShowCaller: false,
+	}
+
+	logWithoutCaller := NewLoggerWithConfig(configWithoutCaller)
+	defer logWithoutCaller.Close()
+
+	if logWithoutCaller.showCaller {
+		t.Error("Expected showCaller to be false")
+	}
+
+	// Test default behavior (should be true)
+	defaultLog := NewLogger()
+	defer defaultLog.Close()
+
+	if !defaultLog.showCaller {
+		t.Error("Expected default showCaller to be true")
+	}
+}
+
+func TestWithContextPreservesShowCaller(t *testing.T) {
+	// Test that WithContext preserves the showCaller configuration
+	config := LoggerConfig{
+		OutputMode: OutputTerminal,
+		LogLevel:   LevelInfo,
+		LogDir:     "test_logs",
+		ShowCaller: false,
+	}
+
+	log := NewLoggerWithConfig(config)
+	defer log.Close()
+
+	ctx := WithRequestID(context.Background(), "test-request")
+	contextLogger := log.WithContext(ctx)
+
+	if contextLogger.showCaller != log.showCaller {
+		t.Errorf("Expected contextLogger.showCaller (%v) to match log.showCaller (%v)",
+			contextLogger.showCaller, log.showCaller)
+	}
+}
+
 // Benchmark tests
 func BenchmarkSimpleLogging(b *testing.B) {
 	log := NewLogger()


### PR DESCRIPTION
### Added
- **Caller Configuration**: Added `ShowCaller` field to `LoggerConfig` struct to control whether caller information is displayed in logs
- **Default Caller Behavior**: Caller information is now shown by default (`ShowCaller: true`)
- **Caller Control Examples**: Updated examples to demonstrate caller configuration usage

### Changed
- **LoggerConfig Structure**: Added `ShowCaller bool` field to `LoggerConfig` struct
- **Logger Struct**: Added `showCaller bool` field to `Logger` struct to store caller configuration
- **initLogWithConfig Function**: Modified to conditionally add caller information based on `ShowCaller` configuration
- **WithContext Method**: Updated to preserve caller configuration when creating new logger instances

### Technical Details
- Caller information is controlled by `zap.AddCaller()` and `zap.AddCallerSkip(1)` options
- When `ShowCaller: false`, these options are not applied to the zap logger
- Default behavior maintains backward compatibility by showing caller information
- All existing functionality remains unchanged